### PR TITLE
Fix toast cleanup logic

### DIFF
--- a/components/ui/use-toast.ts
+++ b/components/ui/use-toast.ts
@@ -9,7 +9,7 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 1000000
+const TOAST_REMOVE_DELAY = 5000
 
 type ToasterToast = ToastProps & {
   id: string
@@ -182,7 +182,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,

--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -9,7 +9,7 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 1000000
+const TOAST_REMOVE_DELAY = 5000
 
 type ToasterToast = ToastProps & {
   id: string
@@ -182,7 +182,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- avoid accumulating listeners in `useToast`
- shorten toast visibility

## Testing
- `pnpm install`
- `npm run lint` *(fails: requires interactive setup)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684c337d8d688321a9834764f0288bb3