### PR TITLE
Add ranking tests

### DIFF
--- a/lib/utils/__tests__/ranking.test.ts
+++ b/lib/utils/__tests__/ranking.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { calculateRanking } from '../ranking'
+
+vi.mock('../../supabase/server', () => {
+  const mockMatches = [
+    {
+      id: 1,
+      tournament_id: 1,
+      category_id: 1,
+      player1_id: 'user1',
+      player2_id: 'user2',
+      status: 'played',
+      player1_confirmed: true,
+      player2_confirmed: true,
+      result_player1_sets: 2,
+      result_player2_sets: 1,
+      result_player1_games: 12,
+      result_player2_games: 8,
+      winner_id: 'user1',
+      created_at: '',
+      updated_at: ''
+    },
+    {
+      id: 2,
+      tournament_id: 1,
+      category_id: 1,
+      player1_id: 'user3',
+      player2_id: 'user1',
+      status: 'played',
+      player1_confirmed: true,
+      player2_confirmed: true,
+      result_player1_sets: 2,
+      result_player2_sets: 0,
+      result_player1_games: 12,
+      result_player2_games: 4,
+      winner_id: 'user3',
+      created_at: '',
+      updated_at: ''
+    }
+  ]
+
+  const chain = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    or: vi.fn().mockResolvedValue({ data: mockMatches, error: null })
+  }
+  return {
+    supabaseAdmin: {
+      from: vi.fn().mockReturnValue(chain)
+    }
+  }
+})
+
+describe('calculateRanking', () => {
+  it('computes ranking stats for a user', async () => {
+    const ranking = await calculateRanking(1, 1, 'user1')
+    expect(ranking).toEqual({
+      matches_played: 2,
+      matches_won: 1,
+      matches_lost: 1,
+      sets_won: 2,
+      sets_lost: 3,
+      games_won: 16,
+      games_lost: 20,
+      points: 3,
+      average: 3 / 8
+    })
+  })
+})

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest run"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",
@@ -66,6 +67,8 @@
     "@types/react-dom": "^19",
     "postcss": "^8.5",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vite": "^6.3.5",
+    "vitest": "^3.2.3"
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+})


### PR DESCRIPTION
## Summary
- set up Vitest
- configure test script
- add calculateRanking unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c363c6f548321aa84bfdf2f3bbd44